### PR TITLE
Fixes and improvements

### DIFF
--- a/source/filesystem.cpp
+++ b/source/filesystem.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <string>
 #include <tuple>
+#include <vector>
 
 #if defined FILESYSTEM_SERVER
 
@@ -22,27 +23,47 @@ namespace filesystem
 #if defined FILESYSTEM_SERVER
 
 static SourceSDK::ModuleLoader dedicated_loader( "dedicated" );
-
-#if defined _WIN32
-
-static const char FileSystemFactory_sym[] = "\x55\x8B\xEC\x68\x2A\x2A\x2A\x2A\xFF\x75\x08\xE8";
-static const size_t FileSystemFactory_symlen = sizeof( FileSystemFactory_sym ) - 1;
-
-#elif defined __linux
-
-static const char FileSystemFactory_sym[] = "@_Z17FileSystemFactoryPKcPi";
-static const size_t FileSystemFactory_symlen = 0;
-
-#elif defined __APPLE__
-
-static const char FileSystemFactory_sym[] = "@__Z17FileSystemFactoryPKcPi";
-static const size_t FileSystemFactory_symlen = 0;
-
-#endif
+static SourceSDK::ModuleLoader server_loader( "server" );
 
 #elif defined FILESYSTEM_CLIENT
 
 static SourceSDK::FactoryLoader filesystem_loader( "filesystem_stdio" );
+
+#endif
+
+struct Symbol
+{
+	std::string name;
+	size_t length;
+
+	Symbol( const std::string &nam, size_t len = 0 ) :
+		name( nam ), length( len ) { }
+
+	static Symbol FromSignature( const std::string &signature )
+	{
+		return Symbol( signature, signature.size( ) );
+	}
+
+	static Symbol FromName( const std::string &name )
+	{
+		return Symbol( "@" + name );
+	}
+};
+
+#if defined SYSTEM_WINDOWS
+
+static const std::vector<Symbol> FileSystemFactory_syms = {
+	Symbol::FromName( "?FileSystemFactory@@YAPEAXPEBDPEAH@Z" ),
+	Symbol::FromSignature( "\x55\x8B\xEC\x68\x2A\x2A\x2A\x2A\xFF\x75\x08\xE8" )
+};
+
+static const Symbol g_pFullFileSystem_sym = Symbol::FromName( "?g_pFullFileSystem@@3PEAVIFileSystem@@EA" );
+
+#elif defined SYSTEM_POSIX
+
+static const std::vector<Symbol> FileSystemFactory_syms = { Symbol::FromName( "_Z17FileSystemFactoryPKcPi" ) };
+
+static const Symbol g_pFullFileSystem_sym = Symbol::FromName( "g_pFullFileSystem" );
 
 #endif
 
@@ -184,17 +205,47 @@ void Initialize( GarrysMod::Lua::ILuaBase *LUA )
 
 #if defined FILESYSTEM_SERVER
 
-	SymbolFinder symfinder;
+	CBaseFileSystem *fsystem = nullptr;
+	{
+		SymbolFinder symfinder;
 
-	CreateInterfaceFn factory = reinterpret_cast<CreateInterfaceFn>( symfinder.Resolve(
-		dedicated_loader.GetModule( ), FileSystemFactory_sym, FileSystemFactory_symlen
-	) );
-	if( factory == nullptr )
-		LUA->ThrowError( "unable to retrieve dedicated factory" );
+		CreateInterfaceFn factory = nullptr;
+		for( const auto &symbol : FileSystemFactory_syms )
+		{
+			factory = reinterpret_cast<CreateInterfaceFn>( symfinder.Resolve(
+				dedicated_loader.GetModule( ),
+				symbol.name.c_str( ),
+				symbol.length
+			) );
+			if( factory != nullptr )
+				break;
+		}
 
-	CBaseFileSystem *fsystem = static_cast<CBaseFileSystem *>( factory( FILESYSTEM_INTERFACE_VERSION, nullptr ) );
-	if( fsystem == nullptr )
-		LUA->ThrowError( "failed to initialize IFileSystem" );
+		if( factory == nullptr )
+		{
+			CBaseFileSystem **filesystem_ptr =
+				reinterpret_cast<CBaseFileSystem **>( symfinder.Resolve(
+					dedicated_loader.GetModule( ),
+					g_pFullFileSystem_sym.name.c_str( ),
+					g_pFullFileSystem_sym.length
+				) );
+			if( filesystem_ptr == nullptr )
+				filesystem_ptr =
+				reinterpret_cast<CBaseFileSystem **>( symfinder.Resolve(
+					server_loader.GetModule( ),
+					g_pFullFileSystem_sym.name.c_str( ),
+					g_pFullFileSystem_sym.length
+				) );
+
+			if( filesystem_ptr != nullptr )
+				fsystem = *filesystem_ptr;
+		}
+		else
+		{
+			fsystem =
+				static_cast<CBaseFileSystem *>( factory( FILESYSTEM_INTERFACE_VERSION, nullptr ) );
+		}
+	}
 
 #elif defined FILESYSTEM_CLIENT
 

--- a/source/filesystem.cpp
+++ b/source/filesystem.cpp
@@ -130,7 +130,7 @@ LUA_FUNCTION_STATIC( GetSearchPaths )
 {
 	if( LUA->GetType( 1 ) <= GarrysMod::Lua::Type::NIL )
 	{
-		std::unordered_map< std::string, std::set<std::string> > searchpaths = filesystem.GetSearchPaths( );
+		const std::unordered_map<std::string, std::set<std::string>> searchpaths = filesystem.GetSearchPaths( );
 
 		LUA->CreateTable( );
 		for( auto it = searchpaths.begin( ); it != searchpaths.end( ); ++it )
@@ -152,7 +152,7 @@ LUA_FUNCTION_STATIC( GetSearchPaths )
 	}
 	else
 	{
-		std::set<std::string> searchpaths = filesystem.GetSearchPaths( LUA->CheckString( 1 ) );
+		const std::set<std::string> searchpaths = filesystem.GetSearchPaths( LUA->CheckString( 1 ) );
 
 		LUA->CreateTable( );
 		size_t npaths = 0;
@@ -192,13 +192,13 @@ void Initialize( GarrysMod::Lua::ILuaBase *LUA )
 	if( factory == nullptr )
 		LUA->ThrowError( "unable to retrieve dedicated factory" );
 
-	IFileSystem *fsystem = static_cast<IFileSystem *>( factory( FILESYSTEM_INTERFACE_VERSION, nullptr ) );
+	CBaseFileSystem *fsystem = static_cast<CBaseFileSystem *>( factory( FILESYSTEM_INTERFACE_VERSION, nullptr ) );
 	if( fsystem == nullptr )
 		LUA->ThrowError( "failed to initialize IFileSystem" );
 
 #elif defined FILESYSTEM_CLIENT
 
-	IFileSystem *fsystem = filesystem_loader.GetInterface<IFileSystem>( FILESYSTEM_INTERFACE_VERSION );
+	CBaseFileSystem *fsystem = filesystem_loader.GetInterface<CBaseFileSystem>( FILESYSTEM_INTERFACE_VERSION );
 	if( fsystem == nullptr )
 		LUA->ThrowError( "unable to initialize IFileSystem" );
 

--- a/source/filesystemwrapper.hpp
+++ b/source/filesystemwrapper.hpp
@@ -7,7 +7,6 @@
 #include <unordered_set>
 #include <unordered_map>
 
-class IFileSystem;
 class CBaseFileSystem;
 
 namespace file
@@ -26,7 +25,7 @@ public:
 	Wrapper( );
 	~Wrapper( );
 
-	bool Initialize( IFileSystem *fsinterface );
+	bool Initialize( CBaseFileSystem *fsinterface );
 
 	file::Base *Open(
 		const std::string &filepath,
@@ -44,22 +43,22 @@ public:
 	bool Remove( const std::string &path, const std::string &pathid );
 	bool MakeDirectory( const std::string &path, const std::string &pathid );
 
-	std::pair< std::set<std::string>, std::set<std::string> > Find(
+	std::pair<std::set<std::string>, std::set<std::string>> Find(
 		const std::string &path,
 		const std::string &pathid
 	) const;
 
-	std::unordered_map< std::string, std::set<std::string> > GetSearchPaths( ) const;
+	std::unordered_map<std::string, std::set<std::string>> GetSearchPaths( ) const;
 	std::set<std::string> GetSearchPaths( const std::string &pathid ) const;
 	bool AddSearchPath( const std::string &path, const std::string &pathid );
 	bool RemoveSearchPath( const std::string &path, const std::string &pathid );
 
 private:
-	enum WhitelistType
+	enum class WhitelistType
 	{
-		WhitelistRead,
-		WhitelistWrite,
-		WhitelistSearchPath
+		Read,
+		Write,
+		SearchPath
 	};
 
 	bool IsPathIDAllowed( std::string &pathid, WhitelistType whitelist_type ) const;
@@ -80,11 +79,11 @@ private:
 	) const;
 
 	static const size_t max_tempbuffer_len;
-	static std::unordered_set<std::string> whitelist_extensions;
-	static std::unordered_set<std::string> whitelist_pathid[];
+	static const std::unordered_set<std::string> whitelist_extensions;
+	static const std::unordered_set<std::string> whitelist_pathid[];
 	static std::unordered_map<std::string, std::string> whitelist_writepaths;
 
-	IFileSystem *filesystem;
+	CBaseFileSystem *filesystem;
 	std::string garrysmod_fullpath;
 };
 

--- a/source/filevalve.cpp
+++ b/source/filevalve.cpp
@@ -1,11 +1,10 @@
 #include "filevalve.hpp"
-
-#include <filesystem.h>
+#include "basefilesystem.hpp"
 
 namespace file
 {
 
-Valve::Valve( IFileSystem *fsystem, FileHandle_t handle ) :
+Valve::Valve( CBaseFileSystem *fsystem, FileHandle_t handle ) :
 	filesystem( fsystem ),
 	filehandle( handle )
 { }

--- a/source/filevalve.hpp
+++ b/source/filevalve.hpp
@@ -3,7 +3,7 @@
 #include "filebase.hpp"
 
 typedef void *FileHandle_t;
-class IFileSystem;
+class CBaseFileSystem;
 
 namespace file
 {
@@ -11,7 +11,7 @@ namespace file
 class Valve : public Base
 {
 public:
-	Valve( IFileSystem *fsystem, FileHandle_t handle );
+	Valve( CBaseFileSystem *fsystem, FileHandle_t handle );
 	~Valve( );
 
 	bool Valid( ) const;
@@ -30,7 +30,7 @@ public:
 	size_t Write( const void *buffer, size_t len );
 
 private:
-	IFileSystem *filesystem;
+	CBaseFileSystem *filesystem;
 	FileHandle_t filehandle;
 };
 

--- a/source/posix/filesystemwrapper.cpp
+++ b/source/posix/filesystemwrapper.cpp
@@ -257,13 +257,12 @@ std::unordered_map<std::string, std::set<std::string>> Wrapper::GetSearchPaths( 
 			pathIDInfo->m_pDebugPathID == nullptr )
 			continue;
 
-		const WilloxHallOfShame *m_pPackFile = searchpath.m_pPackFile;
-		if( m_pPackFile != nullptr )
-		{
-			std::string filepath = m_pPackFile->filepath;
-			filepath += ".vpk";
-			searchpaths[pathIDInfo->m_pDebugPathID].insert( filepath );
-		}
+		const auto packFile = searchpath.m_pPackFile;
+		const auto packFile2 = searchpath.m_pPackFile2;
+		if( packFile != nullptr )
+			searchpaths[pathIDInfo->m_pDebugPathID].insert( packFile->m_ZipName.Get( ) );
+		else if( packFile2 != nullptr )
+			searchpaths[pathIDInfo->m_pDebugPathID].insert( packFile2->m_pszFullPathName );
 		else
 			searchpaths[pathIDInfo->m_pDebugPathID].insert( searchpath.m_pDebugPath );
 	}

--- a/source/win32/filesystemwrapper.cpp
+++ b/source/win32/filesystemwrapper.cpp
@@ -420,13 +420,12 @@ std::unordered_map<std::string, std::set<std::string>> Wrapper::GetSearchPaths( 
 			pathIDInfo->m_pDebugPathID == nullptr )
 			continue;
 
-		const WilloxHallOfShame *m_pPackFile = searchpath.m_pPackFile;
-		if( m_pPackFile != nullptr )
-		{
-			std::string filepath = m_pPackFile->filepath;
-			filepath += ".vpk";
-			searchpaths[pathIDInfo->m_pDebugPathID].insert( filepath );
-		}
+		const auto packFile = searchpath.m_pPackFile;
+		const auto packFile2 = searchpath.m_pPackFile2;
+		if( packFile != nullptr )
+			searchpaths[pathIDInfo->m_pDebugPathID].insert( packFile->m_ZipName.Get( ) );
+		else if( packFile2 != nullptr )
+			searchpaths[pathIDInfo->m_pDebugPathID].insert( packFile2->m_pszFullPathName );
 		else
 			searchpaths[pathIDInfo->m_pDebugPathID].insert( searchpath.m_pDebugPath );
 	}


### PR DESCRIPTION
Cleaned up code
Use CBaseFileSystem everywhere instead of IFileSystem
Fixed compilation warnings
Added POSIX implementation of filesystem::Wrapper::GetPath
Reduced max_tempbuffer_len to 2048 to avoid exploding the stack
Improved CBaseFileSystem definition
Fixed filesystem interface retrieving code (and it should work on x86-64!)
Improved GetSearchPaths